### PR TITLE
Fixing downsample function

### DIFF
--- a/optosim/super_resolution/model.py
+++ b/optosim/super_resolution/model.py
@@ -142,7 +142,7 @@ class SuperResolutionModel:
         else:
             print("Loss curves not available. Ensure you have trained the models.")
 
-    def visualize_heatmaps_with_positions(self, X_low_res, X_high_res, y_true_pos, num_plots=10):
+    def visualize_heatmaps_with_positions(self, X_low_res, X_high_res, y_true_pos, num_plots=10, radius=2.5):
         """
         Visualize input and output heatmaps along with true and predicted positions.
 
@@ -161,7 +161,7 @@ class SuperResolutionModel:
 
         # Predict true positions
         X_high_res_pred, y_pred_pos = self.predict(X_low_res_flat)
-        simple_pred_pos = weighted_average_estimator(X_low_res, 2.5)
+        simple_pred_pos = weighted_average_estimator(X_low_res, radius)
 
         num_samples = num_plots
 
@@ -171,7 +171,11 @@ class SuperResolutionModel:
             # Plot input low-resolution heatmap
             plt.subplot(1, 3, 1)
             plt.imshow(
-                X_low_res[i], cmap="hot", interpolation="nearest", origin="lower", extent=[-2.5, 2.5, -2.5, 2.5]
+                X_low_res[i],
+                cmap="hot",
+                interpolation="nearest",
+                origin="lower",
+                extent=[-radius, radius, -radius, radius],
             )
             plt.scatter(y_true_pos[i, 0], y_true_pos[i, 1], c="r", marker="x", label="True Position")
             plt.scatter(y_pred_pos[i, 0], y_pred_pos[i, 1], c="b", label="Predicted Position")
@@ -185,7 +189,7 @@ class SuperResolutionModel:
                 cmap="hot",
                 interpolation="nearest",
                 origin="lower",
-                extent=[-2.5, 2.5, -2.5, 2.5],
+                extent=[-radius, radius, -radius, radius],
             )
             plt.scatter(y_true_pos[i, 0], y_true_pos[i, 1], c="r", marker="x", label="True Position")
             plt.scatter(y_pred_pos[i, 0], y_pred_pos[i, 1], c="b", label="Predicted Position")
@@ -195,7 +199,11 @@ class SuperResolutionModel:
             # Plot true and predicted positions
             plt.subplot(1, 3, 3)
             plt.imshow(
-                X_high_res[i], cmap="hot", interpolation="nearest", origin="lower", extent=[-2.5, 2.5, -2.5, 2.5]
+                X_high_res[i],
+                cmap="hot",
+                interpolation="nearest",
+                origin="lower",
+                extent=[-radius, radius, -radius, radius],
             )
             plt.scatter(y_true_pos[i, 0], y_true_pos[i, 1], c="r", marker="x", label="True Position")
             plt.scatter(y_pred_pos[i, 0], y_pred_pos[i, 1], c="b", label="Predicted Position")

--- a/optosim/super_resolution/model_utils.py
+++ b/optosim/super_resolution/model_utils.py
@@ -124,6 +124,52 @@ def congrid(a, newdims, method="linear", centre=False, minusone=False):
         return None
 
 
+# def downsample_heatmaps_to_dimensions(heatmaps, new_height, new_width):
+#     """
+#     Downsample a list of heatmaps to specified dimensions using averaging.
+
+#     Args:
+#         heatmaps (list of numpy.ndarray): List of high-resolution heatmaps.
+#         new_height (int): The desired height of the downsampled heatmaps.
+#         new_width (int): The desired width of the downsampled heatmaps.
+
+#     Returns:
+#         list of numpy.ndarray: List of downsampled heatmaps.
+#     """
+#     downsampled_heatmaps = []
+
+#     for heatmap in heatmaps:
+#         # Get the dimensions of the original heatmap
+#         reshaped_heatmap = congrid(heatmap, (new_height, new_width), method="linear", centre=True, minusone=False)
+#         downsampled_heatmaps.append(reshaped_heatmap)
+
+#     return np.asarray(downsampled_heatmaps)
+
+
+def rebin_single(data, N):
+    import numpy as np
+    from scipy.interpolate import RegularGridInterpolator
+
+    # This function rebins a single 2D heatmap
+    x = np.linspace(0, 19, 20)
+    y = np.linspace(0, 19, 20)
+    f = RegularGridInterpolator((x, y), data)
+    x_fine = np.linspace(0, 19, 400)
+    y_fine = np.linspace(0, 19, 400)
+    mesh_x, mesh_y = np.meshgrid(x_fine, y_fine)
+    pts = np.vstack((mesh_x.ravel(), mesh_y.ravel())).T
+    fine_data = f(pts).reshape(400, 400)
+    fine_data *= np.sum(data) / np.sum(fine_data)
+    block_size = 400 // N
+    rebinned_data = np.zeros((N, N))
+    for i in range(N):
+        for j in range(N):
+            rebinned_data[j, i] = np.sum(
+                fine_data[i * block_size : (i + 1) * block_size, j * block_size : (j + 1) * block_size]
+            )
+    return rebinned_data
+
+
 def downsample_heatmaps_to_dimensions(heatmaps, new_height, new_width):
     """
     Downsample a list of heatmaps to specified dimensions using averaging.
@@ -136,14 +182,16 @@ def downsample_heatmaps_to_dimensions(heatmaps, new_height, new_width):
     Returns:
         list of numpy.ndarray: List of downsampled heatmaps.
     """
-    downsampled_heatmaps = []
 
-    for heatmap in heatmaps:
-        # Get the dimensions of the original heatmap
-        reshaped_heatmap = congrid(heatmap, (new_height, new_width), method="linear", centre=True, minusone=False)
-        downsampled_heatmaps.append(reshaped_heatmap)
+    data = heatmaps
+    N = new_height
 
-    return np.asarray(downsampled_heatmaps)
+    # This function handles a 3D array of heatmaps
+    num_heatmaps = data.shape[0]
+    rebinned_data = np.zeros((num_heatmaps, N, N))
+    for i in range(num_heatmaps):
+        rebinned_data[i] = rebin_single(data[i], N)
+    return rebinned_data
 
 
 def weighted_average_estimator(X, r):
@@ -158,6 +206,7 @@ def weighted_average_estimator(X, r):
     """
     x = (-r * X[:, 0, 0] + r * X[:, 0, 1] - r * X[:, 1, 0] + r * X[:, 1, 1]) / np.sum(X, axis=(1, 2))
     y = (-r * X[:, 0, 0] - r * X[:, 0, 1] + r * X[:, 1, 0] + r * X[:, 1, 1]) / np.sum(X, axis=(1, 2))
+
     return list(zip(x, y))
 
 

--- a/optosim/super_resolution/model_utils.py
+++ b/optosim/super_resolution/model_utils.py
@@ -147,20 +147,54 @@ def congrid(a, newdims, method="linear", centre=False, minusone=False):
 
 
 def rebin_single(data, N):
+    """
+    Rebin a single 2D heatmap. This function is used by downsample_heatmaps_to_dimensions.
+    It takes a single heatmap and rebins it to the desired dimensions. First it
+    interpolates the heatmap to a higher resolution, then it averages the values
+    in each block of the higher resolution heatmap to get the value for the
+    rebinned heatmap.
+
+    Args:
+        data (numpy.ndarray): The heatmap.
+        N (int): The desired height and width of the rebinned heatmap.
+
+    Returns:
+        numpy.ndarray: The rebinned heatmap.
+    """
+
     import numpy as np
     from scipy.interpolate import RegularGridInterpolator
 
-    # This function rebins a single 2D heatmap
-    x = np.linspace(0, 19, 20)
-    y = np.linspace(0, 19, 20)
+    # Get the number of pixels per side in the original grid
+    original_n = data.shape[0]
+
+    # Define a new grid with 20 times the resolution of the original grid
+    # it is used for interpolation
+    extremely_high_resolution = original_n * 20
+
+    # Create a function that interpolates the data
+    x = np.linspace(0, original_n - 1, original_n)
+    y = np.linspace(0, original_n - 1, original_n)
     f = RegularGridInterpolator((x, y), data)
-    x_fine = np.linspace(0, 19, 400)
-    y_fine = np.linspace(0, 19, 400)
+
+    # Create a new grid of points to interpolate at
+    x_fine = np.linspace(0, original_n - 1, extremely_high_resolution)
+    y_fine = np.linspace(0, original_n - 1, extremely_high_resolution)
     mesh_x, mesh_y = np.meshgrid(x_fine, y_fine)
+
+    # Interpolate the data at the new grid points
     pts = np.vstack((mesh_x.ravel(), mesh_y.ravel())).T
+
+    # Reshape the interpolated data to a 2D array
     fine_data = f(pts).reshape(400, 400)
+
+    # Normalize the interpolated data to have the same total value as the original data
     fine_data *= np.sum(data) / np.sum(fine_data)
-    block_size = 400 // N
+
+    # Rebin the data to the desired dimensions
+    block_size = extremely_high_resolution // N
+
+    # Create a new array to hold the rebinned data
     rebinned_data = np.zeros((N, N))
     for i in range(N):
         for j in range(N):


### PR DESCRIPTION
ChatGPT helped us to come up with a new method for doing the downsampling. 

The old method did not work that well in some cases, giving weird values of total hits and weird distributions.  For now I leave the old version as a comment because we might want to compare them. (We can also just delete it).

The idea now is that to do the interpolation we make a 400x400 grid interpolated from the 20x20, and from that one we make the usual NxN grid with n in [2,20]. 